### PR TITLE
update MOM6 to point to EMC 20200913 commit which corresponding to GFDL 20200909 commit

### DIFF
--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,10 +1,10 @@
-Tue Sep  8 20:05:44 UTC 2020
+Mon Sep 14 16:51:47 EDT 2020
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_ccpp_cmeps
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux
 Checking test 001 cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -56,7 +56,7 @@ Test 001 cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_satmedmf_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_satmedmf_ccpp_cmeps
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf
 Checking test 002 cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -108,7 +108,7 @@ Test 002 cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold384_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR384_ccpp_cmeps
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux
 Checking test 003 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -160,7 +160,7 @@ Test 003 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_bmrt_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_bmrt_ccpp_cmeps
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt
 Checking test 004 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -210,9 +210,10 @@ Checking test 004 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt results ....
 Test 004 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt PASS
 
 
+
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux
 Checking test 005 cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -267,9 +268,11 @@ Checking test 005 cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux results ....
 Test 005 cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux PASS
 
 
+
+
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux
 Checking test 006 cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux results ....
  Comparing phyf072.tile1.nc .........OK
  Comparing phyf072.tile2.nc .........OK
@@ -326,7 +329,7 @@ Test 006 cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_restart
 Checking test 007 cpld_fv3_ccpp_mom6_cice_cmeps_restart results ....
  Comparing phyf072.tile1.nc .........OK
  Comparing phyf072.tile2.nc .........OK
@@ -381,9 +384,10 @@ Checking test 007 cpld_fv3_ccpp_mom6_cice_cmeps_restart results ....
 Test 007 cpld_fv3_ccpp_mom6_cice_cmeps_restart PASS
 
 
+
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads
 Checking test 008 cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -438,9 +442,10 @@ Checking test 008 cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads results ....
 Test 008 cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads PASS
 
 
+
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp
 Checking test 009 cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -495,9 +500,11 @@ Checking test 009 cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp results ....
 Test 009 cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp PASS
 
 
+
+
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_warm_satmedmf_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_warm_satmedmf_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf
 Checking test 010 cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -552,9 +559,11 @@ Checking test 010 cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf results ....
 Test 010 cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf PASS
 
 
+
+
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp384_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp384_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux
 Checking test 011 cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -611,7 +620,7 @@ Test 011 cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmrt_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmrt_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt
 Checking test 012 cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -706,7 +715,7 @@ Test 012 cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_bmwav_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_bmwav_ccpp_cmeps
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt
 Checking test 013 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -758,7 +767,7 @@ Test 013 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmwav_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmwav_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt
 Checking test 014 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -818,7 +827,7 @@ Test 014 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_debug_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_debug_ccpp_cmeps
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug
 Checking test 015 cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -870,7 +879,7 @@ Test 015 cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug PASS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_6h_warm_debug_ccpp_cmeps
 mediator baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_6h_warm_debug_ccpp_cmeps/RESTART
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/S2S_RT/rt_66763/cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jiande.Wang/S2S_RT/rt_81087/cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug
 Checking test 016 cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -926,5 +935,7 @@ Test 016 cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Sep  8 21:34:56 UTC 2020
-Elapsed time: 01h:29m:13s. Have a nice day!
+Mon Sep 14 18:18:08 EDT 2020
+Elapsed time: 01h:26m:23s. Have a nice day!
+
+

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,10 +1,10 @@
-Tue Sep  8 12:31:11 CDT 2020
+Mon Sep 14 20:59:47 CDT 2020
 Start Regression test
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_ccpp_cmeps
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux
 Checking test 001 cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -56,7 +56,7 @@ Test 001 cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_satmedmf_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_satmedmf_ccpp_cmeps
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf
 Checking test 002 cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -108,7 +108,7 @@ Test 002 cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold384_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR384_ccpp_cmeps
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux
 Checking test 003 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -160,7 +160,7 @@ Test 003 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_bmrt_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_bmrt_ccpp_cmeps
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt
 Checking test 004 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -212,7 +212,7 @@ Test 004 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux
 Checking test 005 cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -266,10 +266,9 @@ Checking test 005 cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux results ....
  Comparing ufs.s2s.cpl.r.2016-10-05-00000.nc .........OK
 Test 005 cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux PASS
 
-
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux
 Checking test 006 cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux results ....
  Comparing phyf072.tile1.nc .........OK
  Comparing phyf072.tile2.nc .........OK
@@ -326,7 +325,7 @@ Test 006 cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_restart
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_restart
 Checking test 007 cpld_fv3_ccpp_mom6_cice_cmeps_restart results ....
  Comparing phyf072.tile1.nc .........OK
  Comparing phyf072.tile2.nc .........OK
@@ -380,10 +379,9 @@ Checking test 007 cpld_fv3_ccpp_mom6_cice_cmeps_restart results ....
  Comparing ufs.s2s.cpl.r.2016-10-06-00000.nc .........OK
 Test 007 cpld_fv3_ccpp_mom6_cice_cmeps_restart PASS
 
-
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads
 Checking test 008 cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -437,10 +435,9 @@ Checking test 008 cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads results ....
  Comparing ufs.s2s.cpl.r.2016-10-05-00000.nc .........OK
 Test 008 cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads PASS
 
-
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp
 Checking test 009 cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -494,10 +491,9 @@ Checking test 009 cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp results ....
  Comparing ufs.s2s.cpl.r.2016-10-05-00000.nc .........OK
 Test 009 cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp PASS
 
-
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_warm_satmedmf_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_warm_satmedmf_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf
 Checking test 010 cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -554,7 +550,7 @@ Test 010 cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp384_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp384_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux
 Checking test 011 cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -611,7 +607,7 @@ Test 011 cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmrt_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmrt_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt
 Checking test 012 cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -706,7 +702,7 @@ Test 012 cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_bmwav_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_bmwav_ccpp_cmeps
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt
 Checking test 013 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -758,7 +754,7 @@ Test 013 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmwav_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmwav_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt
 Checking test 014 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -818,7 +814,7 @@ Test 014 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_debug_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_debug_ccpp_cmeps
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug
 Checking test 015 cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -870,7 +866,7 @@ Test 015 cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug PASS
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_6h_warm_debug_ccpp_cmeps
 mediator baseline dir = /work/noaa/nems/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_6h_warm_debug_ccpp_cmeps/RESTART
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/S2S_RT/rt_142609/cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug
+working dir  = /work/noaa/stmp/jiwang/stmp/jiwang/S2S_RT/rt_39008/cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug
 Checking test 016 cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -926,5 +922,6 @@ Test 016 cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Sep  8 14:46:15 CDT 2020
-Elapsed time: 02h:15m:06s. Have a nice day!
+Mon Sep 14 22:44:18 CDT 2020
+
+

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,10 +1,10 @@
-Tue Sep  8 22:30:49 UTC 2020
+Mon Sep 14 20:28:36 EDT 2020
 Start Regression test
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_ccpp_cmeps
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux
 Checking test 001 cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -56,7 +56,7 @@ Test 001 cpld_fv3_ccpp_mom6_cice_cmeps_cold_atm_flux PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_satmedmf_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_satmedmf_ccpp_cmeps
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf
 Checking test 002 cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -108,7 +108,7 @@ Test 002 cpld_fv3_ccpp_mom6_cice_cmeps_cold_satmedmf PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold384_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR384_ccpp_cmeps
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux
 Checking test 003 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -160,7 +160,7 @@ Test 003 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_atm_flux PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_bmrt_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_bmrt_ccpp_cmeps
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt
 Checking test 004 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -212,7 +212,7 @@ Test 004 cpld_fv3_ccpp_384_mom6_cice_cmeps_cold_bmark_rt PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux
 Checking test 005 cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -269,7 +269,7 @@ Test 005 cpld_fv3_ccpp_mom6_cice_cmeps_2d_atm_flux PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux
 Checking test 006 cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux results ....
  Comparing phyf072.tile1.nc .........OK
  Comparing phyf072.tile2.nc .........OK
@@ -326,7 +326,7 @@ Test 006 cpld_fv3_ccpp_mom6_cice_cmeps_3d_atm_flux PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_3d_warm_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_restart
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_restart
 Checking test 007 cpld_fv3_ccpp_mom6_cice_cmeps_restart results ....
  Comparing phyf072.tile1.nc .........OK
  Comparing phyf072.tile2.nc .........OK
@@ -383,7 +383,7 @@ Test 007 cpld_fv3_ccpp_mom6_cice_cmeps_restart PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads
 Checking test 008 cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -440,7 +440,7 @@ Test 008 cpld_fv3_ccpp_mom6_cice_cmeps_2d_2threads PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp
 Checking test 009 cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -497,7 +497,7 @@ Test 009 cpld_fv3_ccpp_mom6_cice_cmeps_2d_decomp PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_warm_satmedmf_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_warm_satmedmf_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf
 Checking test 010 cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -554,7 +554,7 @@ Test 010 cpld_fv3_ccpp_mom6_cice_cmeps_1d_satmedmf PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp384_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_2d_warm_ccpp384_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux
 Checking test 011 cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -611,7 +611,7 @@ Test 011 cpld_fv3_ccpp_384_mom6_cice_cmeps_2d_atm_flux PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmrt_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmrt_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt
 Checking test 012 cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -706,7 +706,7 @@ Test 012 cpld_fv3_ccpp_384_mom6_cice_cmeps_1d_bmark_rt PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_bmwav_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_bmwav_ccpp_cmeps
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt
 Checking test 013 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -758,7 +758,7 @@ Test 013 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_cold_bmark_rt PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmwav_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_1d_bmwav_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt
 Checking test 014 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -818,7 +818,7 @@ Test 014 cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_cold_debug_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/MEDIATOR_debug_ccpp_cmeps
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug
 Checking test 015 cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug results ....
  Comparing phyf001.tile1.nc .........OK
  Comparing phyf001.tile2.nc .........OK
@@ -870,7 +870,7 @@ Test 015 cpld_fv3_ccpp_mom6_cice_cmeps_cold_debug PASS
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_6h_warm_debug_ccpp_cmeps
 mediator baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/FV3-MOM6-CICE5/develop-20200907/RT-Baselines_6h_warm_debug_ccpp_cmeps/RESTART
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/S2S_RT/rt_109096/cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug
+working dir  = /gpfs/dell2/ptmp/Jiande.Wang/S2S_RT/rt_184049/cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug
 Checking test 016 cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -926,5 +926,5 @@ Test 016 cpld_fv3_ccpp_mom6_cice_cmeps_6h_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Sep  9 08:15:45 UTC 2020
-Elapsed time: 09h:44m:59s. Have a nice day!
+Tue Sep 15 02:44:26 EDT 2020
+Elapsed time: 06h:15m:54s. Have a nice day!


### PR DESCRIPTION


### Description of changes
update EMC MOM6 to GFDL 20200909 commit (dev-master-candidate-NCAR-2020-08-11)
### Specific notes

Issues Fixed (include github issue #):
Issue #180 
[hera-log.pdf](https://github.com/ufs-community/ufs-s2s-model/files/5222393/hera-log.pdf)
[Orion-log.pdf](https://github.com/ufs-community/ufs-s2s-model/files/5222397/Orion-log.pdf)



Are changes expected to change answers?
- bit for bit (yes)

Specific changes:
- changes in parm directory (no)
- changes in module files (no)
- new tests added or removed (no)

Testing performed:
- machines: orion, hera and Dell-p3
- details: no answer change, see attached run log

Hashes used for testing:
- NEMS: 9d05172b
- CMEPS: 5e63bd4d
- FV3: 0975bb66
- MOM6: 3ce81f4c
- CICE: 285985c08
- WW3: 96e3f3a8
- FMS: f61416fe
- stochastic_physics: a8e2cc1c8

Co-authored by: Denise Worthen
