### PR TITLE
update CMEPS submodule pointer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,8 +16,8 @@
 	branch = master
 [submodule "CMEPS"]
 	path = CMEPS
-	url = https://github.com/aerorahul/CMEPS.git
-	branch = feature/no-pio
+	url = https://github.com/NOAA-EMC/CMEPS.git
+	branch = emc/develop
 [submodule "WW3"]
 	path = WW3
 	url = https://github.com/NOAA-EMC/WW3.git


### PR DESCRIPTION
### Description of changes
Update CMEPS pointer after https://github.com/NOAA-EMC/CMEPS/pull/16

### Specific notes

Issues Fixed:
develop is pointing to incorrect fork of CMEPS

Are changes expected to change answers?
- bit for bit: yes
- more substantial: no

Specific changes:
- changes in parm directory (no)
- changes in module files (no)
- new tests added or removed (no)

Testing performed:
- machines:
- details:

Hashes used for testing:
- NEMS
- CMEPS: https://github.com/NOAA-EMC/CMEPS/commit/4d50adf2c63749241afbc028cbe245881b087585
- FV3:
- MOM6:
- CICE:
- WW3:
- FMS:
- stochastic_physics:
